### PR TITLE
Update embeds.xml load order

### DIFF
--- a/embeds.xml
+++ b/embeds.xml
@@ -1,4 +1,5 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
+  <Include file="Libs\LibSharedMedia-3.0\lib.xml"/>
   <Include file="Libs\AceAddon-3.0\AceAddon-3.0.xml"/>
   <Include file="Libs\AceGUI-3.0\AceGUI-3.0.xml"/>
   <Include file="Libs\AceConsole-3.0\AceConsole-3.0.xml"/>
@@ -8,5 +9,4 @@
   <Include file="Libs\AceDB-3.0\AceDB-3.0.xml"/>
   <Include file="Libs\AceDBOptions-3.0\AceDBOptions-3.0.xml"/>
   <Include file="Libs\AceLocale-3.0\AceLocale-3.0.xml"/>
-  <Include file="Libs\LibSharedMedia-3.0\lib.xml"/>
 </Ui>


### PR DESCRIPTION
LibSharedMedia used before its load order in the embeds.xml. Moved to the top of the list so it is loaded before Libs\AceGUI-3.0-SharedMediaWidgets\widget.xml calls it with LibStub