### PR TITLE
Add existing Debouncing Logic to other events as well to avoid event …

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -719,12 +719,14 @@ end
 
 -- Event handler for POI updates (boss positions)
 function KeystonePolaris:SCENARIO_POI_UPDATE()
-    if self.UpdatePercentageText then self:UpdatePercentageText() end
+    if self._QueuePullUpdate then self:_QueuePullUpdate() end
 end
 
 -- Event handler for criteria updates (enemy forces percentage changes)
+-- This event fires once per mob killed, so debouncing is critical to avoid
+-- hanging the game when a large pack dies all at once.
 function KeystonePolaris:SCENARIO_CRITERIA_UPDATE()
-    if self.UpdatePercentageText then self:UpdatePercentageText() end
+    if self._QueuePullUpdate then self:_QueuePullUpdate() end
 end
 
 -- Event handler for starting a Mythic+ dungeon

--- a/Modules/PullTracker.lua
+++ b/Modules/PullTracker.lua
@@ -90,7 +90,7 @@ function KeystonePolaris:NAME_PLATE_UNIT_ADDED(_, unit)
         end
     end
     -- Engagement tracking remains via COMBAT_LOG to avoid double counting
-    if self.UpdatePercentageText then self:UpdatePercentageText() end
+    if self._QueuePullUpdate then self:_QueuePullUpdate() end
 end
 
 function KeystonePolaris:NAME_PLATE_UNIT_REMOVED(_, unit)
@@ -103,7 +103,7 @@ function KeystonePolaris:NAME_PLATE_UNIT_REMOVED(_, unit)
         end
         -- Intentionally not calling RemoveEngagedMobByGUID(guid) to avoid Pull% oscillation.
     end
-    if self.UpdatePercentageText then self:UpdatePercentageText() end
+    if self._QueuePullUpdate then self:_QueuePullUpdate() end
 end
 
 -- Update when threat list changes (engagement state)


### PR DESCRIPTION
…spikes hanging the game

I was having massive lag spikes in keys when using your addon. I saw you already had a debouncing function available to handle event spikes, you just hadn't applied it to all places where spikes could occur. I went ahead and added it to a few more places to be safe. I no longer have any lag spikes at all.