### PR TITLE
Add PR templates for contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,25 @@
+---
+name: Bug Fix
+about: Fix broken or incorrect behavior
+labels: bug
+---
+
+## Problem
+
+<!-- What's broken? Include error messages or describe the in-game behavior. -->
+
+## Root Cause
+
+<!-- What was causing the issue? (e.g., event firing order, missing nil guard, API change) -->
+
+## Fix
+
+<!-- What does this PR change to resolve it? -->
+
+## How to Verify
+
+<!-- What in-game scenario reproduces the bug? (e.g., "Enter a +10 key, pull 3 packs, tab out and back") -->
+
+## Related Issues
+
+<!-- Closes #, Depends on #, or delete this section -->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature / Enhancement
+about: Add new functionality or improve existing behavior
+labels: enhancement
+---
+
+## Summary
+
+<!-- What does this PR add or change? Why? -->
+
+## Screenshots
+
+<!-- If this changes the UI, include before/after screenshots. Delete this section otherwise. -->
+
+## Changes
+
+<!-- What files/modules are affected? Note any of the following if applicable:
+- New or changed SavedVariables/defaults
+- New locale strings added
+- New event handlers or timers
+- Changes to platform-gated (isMidnight) code
+-->
+
+## Related Issues
+
+<!-- Closes #, Depends on #, or delete this section -->

--- a/.github/PULL_REQUEST_TEMPLATE/other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other.md
@@ -1,0 +1,20 @@
+---
+name: Other
+about: Docs, CI, data updates, or anything else
+---
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type
+
+<!-- Check one: -->
+- [ ] Documentation / README
+- [ ] CI / GitHub workflows
+- [ ] Data files (seasons, dungeons, bosses)
+- [ ] Other: <!-- describe -->
+
+## Related Issues
+
+<!-- Closes #, Depends on #, or delete this section -->

--- a/.github/PULL_REQUEST_TEMPLATE/translation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/translation.md
@@ -1,0 +1,17 @@
+---
+name: Translation
+about: Add or update translations for a locale
+labels: localization
+---
+
+## Language
+
+<!-- e.g., Korean (koKR), Russian (ruRU), Brazilian Portuguese (ptBR) -->
+
+## Changes
+
+<!-- What did you add or update? New translations, corrections, missing keys? -->
+
+## Related Issues
+
+<!-- Closes #, Depends on #, or delete this section -->


### PR DESCRIPTION
## Summary
- Add 4 PR templates in `.github/PULL_REQUEST_TEMPLATE/` to standardize PR descriptions
  - **Translation** — minimal: language + what changed (for non-developer translators)
  - **Bug Fix** — problem, root cause, fix, and how to verify in-game
  - **Feature / Enhancement** — summary, screenshots, and addon-specific change notes (SavedVariables, locale strings, event handlers, platform gating)
  - **Other** — catch-all for docs, CI, and data file updates with type classification

Contributors see a template picker when opening a new PR and choose the one that fits.