### PR TITLE
Remember Group Reminder window position

### DIFF
--- a/Modules/GroupReminder.lua
+++ b/Modules/GroupReminder.lua
@@ -227,14 +227,23 @@ local function EnsureGroupReminderStyledFrame(self)
 
     local f = CreateFrame("Frame", "KPL_GroupReminderStyled", UIParent, "BackdropTemplate")
     f:SetSize(400, 200) -- Slightly smaller/standard size
-    f:SetPoint("CENTER")
+    local xOff = self.db.profile.groupReminder.popupXOffset or 0
+    local yOff = self.db.profile.groupReminder.popupYOffset or 0
+    f:SetPoint("CENTER", UIParent, "CENTER", xOff, yOff)
     f:SetFrameStrata("DIALOG")
     f:SetClampedToScreen(true)
     f:EnableMouse(true)
     f:SetMovable(true)
     f:RegisterForDrag("LeftButton")
     f:SetScript("OnDragStart", f.StartMoving)
-    f:SetScript("OnDragStop", f.StopMovingOrSizing)
+    f:SetScript("OnDragStop", function(frame)
+        frame:StopMovingOrSizing()
+        local cx, cy = frame:GetCenter()
+        local sw, sh = GetScreenWidth(), GetScreenHeight()
+        local db = self.db.profile.groupReminder
+        db.popupXOffset = cx - sw / 2
+        db.popupYOffset = cy - sh / 2
+    end)
 
     f:SetBackdrop({
         bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
@@ -900,6 +909,22 @@ function KeystonePolaris:GetGroupReminderOptions()
                 width = "full",
                 order = 6,
                 func = function() self:TestGroupReminder() end,
+                disabled = function() return not self.db.profile.groupReminder.enabled end,
+            },
+            resetPopupPosition = {
+                name = "Reset popup position",
+                desc = "Reset the group reminder popup to the center of the screen.",
+                type = "execute",
+                width = "full",
+                order = 7,
+                func = function()
+                    self.db.profile.groupReminder.popupXOffset = 0
+                    self.db.profile.groupReminder.popupYOffset = 0
+                    if self.groupReminderStyledFrame then
+                        self.groupReminderStyledFrame:ClearAllPoints()
+                        self.groupReminderStyledFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+                    end
+                end,
                 disabled = function() return not self.db.profile.groupReminder.enabled end,
             },
             contentHeader = {

--- a/Options.lua
+++ b/Options.lua
@@ -221,6 +221,8 @@ KeystonePolaris.defaults.profile.groupReminder = {
     showGroupDescription = true,
     showAppliedRole = true,
     lastReminder = nil,
+    popupXOffset = 0,
+    popupYOffset = 0,
 }
 
 local expansions = KeystonePolaris.Expansions


### PR DESCRIPTION
## Summary
- Persist the Group Reminder popup's position to saved variables when dragged
- Restore saved position on frame creation (survives `/reload`)
- Add "Reset popup position" button in Group Reminder options

Closes #107

## Test plan
- [x] Open options → Modules → Group Reminder → click "Simulate current season acceptance"
- [x] Drag popup to a non-center position, close it
- [x] `/reload` → simulate again → popup appears at saved position
- [x] Click "Reset popup position" → simulate again → popup returns to center