### PR TITLE
Fix combat taint on secure inform button (#132)

### DIFF
--- a/Modules/Display.lua
+++ b/Modules/Display.lua
@@ -131,25 +131,29 @@ function KeystonePolaris:EnsureInformSecureButton(macroText)
 
         btn:Hide()
         self.informSecureButton = btn
+        btn:ClearAllPoints()
+        if self.displayFrame then
+            btn:SetPoint("TOP", self.displayFrame, "BOTTOM", 0, -6)
+        else
+            btn:SetPoint("CENTER")
+        end
         if self.UpdateInformButtonFrameLayer then
             self:UpdateInformButtonFrameLayer()
         end
     end
 
     local btn = self.informSecureButton
-    btn:ClearAllPoints()
-    if self.displayFrame then
-        btn:SetPoint("TOP", self.displayFrame, "BOTTOM", 0, -6)
-    else
-        btn:SetPoint("CENTER")
-    end
-    if self.UpdateInformButtonFrameLayer then
-        self:UpdateInformButtonFrameLayer()
-    end
 
     if macroText then
-        btn:SetAttribute("type", "macro")
-        btn:SetAttribute("macrotext", macroText)
+        if InCombatLockdown() then
+            self._pendingInformMacro = macroText
+            if self.EnsureInformWatcher then
+                self:EnsureInformWatcher()
+            end
+        else
+            btn:SetAttribute("type", "macro")
+            btn:SetAttribute("macrotext", macroText)
+        end
     end
 end
 
@@ -196,6 +200,12 @@ function KeystonePolaris:EnsureInformWatcher()
         if self._pendingInformMouseEnabled ~= nil and self.informSecureButton and not InCombatLockdown() then
             self.informSecureButton:EnableMouse(self._pendingInformMouseEnabled)
             self._pendingInformMouseEnabled = nil
+        end
+
+        if self._pendingInformMacro and self.informSecureButton and not InCombatLockdown() then
+            self.informSecureButton:SetAttribute("type", "macro")
+            self.informSecureButton:SetAttribute("macrotext", self._pendingInformMacro)
+            self._pendingInformMacro = nil
         end
     end)
 
@@ -313,8 +323,7 @@ function KeystonePolaris:PrepareInformMacro(message)
     else
         btn:EnableMouse(true) -- IMPORTANT
     end
-    btn:Hide() -- Will be shown only when conditions are met in UpdatePercentageText
-    -- Reset cooldown until click
+    self:ApplyInformVisibility(false)
     btn.cooldownEndTime = nil
 end
 

--- a/Modules/Display.lua
+++ b/Modules/Display.lua
@@ -324,7 +324,6 @@ function KeystonePolaris:PrepareInformMacro(message)
         btn:EnableMouse(true) -- IMPORTANT
     end
     self:ApplyInformVisibility(false)
-    btn.cooldownEndTime = nil
 end
 
 


### PR DESCRIPTION
## Summary

Fixes the `ADDON_ACTION_BLOCKED` error reported in #132:

```
[KeystonePolaris/Modules/Display.lua]:140: in function 'EnsureInformSecureButton'
[KeystonePolaris/Modules/Display.lua]:305: in function 'PrepareInformMacro'
[KeystonePolaris/Modules/Display.lua]:1212: in function 'InformGroup'
[KeystonePolaris/Modules/Display.lua]:1054: in function 'UpdatePercentageText'
[KeystonePolaris/Modules/PullTracker.lua]:209
```

`KeystonePolarisSecureInformButton` is a `SecureActionButtonTemplate`. Repositioning it (`ClearAllPoints` / `SetPoint`) and rewriting its `type` / `macrotext` attributes are protected during combat lockdown. `EnsureInformSecureButton` was doing both on every call, including the path that runs from `PullTracker` mid-pull.

Changes in `Modules/Display.lua`:

- Anchor the button only at creation; the position doesn't change after that, so re-anchoring on every call was unnecessary as well as taint-prone.
- When `EnsureInformSecureButton` is called with new macro text in combat, queue it on `_pendingInformMacro` and let the existing `EnsureInformWatcher` apply it on `PLAYER_REGEN_ENABLED` — same pattern already used for visibility and mouse-enable.
- Replace the direct `btn:Hide()` at the end of `PrepareInformMacro` with `ApplyInformVisibility(false)`, which is already combat-safe.

No behavior change out of combat. In combat, the button updates the moment combat ends instead of throwing taint.

## Related Issues

Closes #132