### PR TITLE
Fix combat taint on teleport button (#130)

### DIFF
--- a/Modules/GroupReminder.lua
+++ b/Modules/GroupReminder.lua
@@ -374,7 +374,27 @@ local function EnsureGroupReminderStyledFrame(self)
     return f
 end
 
+function KeystonePolaris:EnsureGroupReminderCombatWatcher()
+    if self._groupReminderCombatWatcher then return end
+    local f = CreateFrame("Frame")
+    f:RegisterEvent("PLAYER_REGEN_ENABLED")
+    f:SetScript("OnEvent", function()
+        if self._pendingGroupReminderArgs and not InCombatLockdown() then
+            local args = self._pendingGroupReminderArgs
+            self._pendingGroupReminderArgs = nil
+            self:ShowStyledGroupReminderPopup(args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+        end
+    end)
+    self._groupReminderCombatWatcher = f
+end
+
 function KeystonePolaris:ShowStyledGroupReminderPopup(zone, groupName, groupComment, roleText, teleportSpellID, teleportSpellUnknown, playstyleText)
+    if InCombatLockdown() then
+        self._pendingGroupReminderArgs = { zone, groupName, groupComment, roleText, teleportSpellID, teleportSpellUnknown, playstyleText }
+        self:EnsureGroupReminderCombatWatcher()
+        return
+    end
+
     local db = self.db.profile.groupReminder
     local f = EnsureGroupReminderStyledFrame(self)
     f.Title:SetText(GetGroupReminderHeaderLabel())


### PR DESCRIPTION
## Summary

Fixes the `ADDON_ACTION_FORBIDDEN` / `RunMacroText()` error reported in #130 — clicking the teleport icon on the group reminder popup does nothing when the popup was first shown during combat.

```
1x [ADDON_ACTION_FORBIDDEN] AddOn 'KeystonePolaris' tried to call the protected function 'RunMacroText()'.
[C]: in function 'RunMacroText'
[Blizzard_FrameXML/SecureTemplates.lua]:452: in function 'handler'
```

The styled group reminder popup hosts a `SecureActionButtonTemplate` (`TeleportLink`). `ShowStyledGroupReminderPopup` unconditionally writes its secure attributes (`type`, `macrotext`) and toggles its `Show`/`Hide` every call, then shows the parent frame. All three operations are taint-prone under combat lockdown — once tainted, clicking the teleport icon raises `ADDON_ACTION_FORBIDDEN` on `RunMacroText()` and the click is dropped silently.

Same family of bug as #132 / #133, different module and different secure button.

### Change

`Modules/GroupReminder.lua`:

- When `ShowStyledGroupReminderPopup` is called while `InCombatLockdown()`, queue the args on `_pendingGroupReminderArgs` and register a `PLAYER_REGEN_ENABLED` watcher (`EnsureGroupReminderCombatWatcher`) — same defer-and-replay pattern PR #133 uses for the inform button.
- On `PLAYER_REGEN_ENABLED`, replay `ShowStyledGroupReminderPopup` with the saved args. The popup now appears the moment combat ends instead of taint-poisoning the secure button.

No behavior change out of combat.

### Note on `LFGListInviteDialog:Hide()`

While auditing for this fix I confirmed `Modules/GroupReminder.lua:647` still calls `LFGListInviteDialog:Hide()` from the `LFG_LIST_APPLICATION_STATUS_UPDATED` handler (under the `suppressQuickJoinToast` option). Hiding a Blizzard secure popup from addon code propagates taint to the frame for the rest of the session regardless of combat state — there is no addon-safe API to dismiss it (`StaticPopupSpecial_Hide`, `HideUIPanel`, etc. taint identically because the calling execution context is the addon).

This PR intentionally does **not** touch that call. The `suppressQuickJoinToast` feature is a product decision; flagging it here for the maintainer's awareness rather than removing or guarding it.

## Related Issues

Closes #130